### PR TITLE
feat: add another WXDC token

### DIFF
--- a/mainnet.tokenlist.json
+++ b/mainnet.tokenlist.json
@@ -41,6 +41,13 @@
     },
     {
       "chainId": 50,
+      "address": "0x8A3cc832Bb6B255622E92dc9d4611F2A94d200DA",
+      "name": "Wrapped XDC",
+      "symbol": "WXDC2",
+      "decimals": 18
+    },
+    {
+      "chainId": 50,
       "address": "0xb3f18b584263191a33169f6393487e43e9586329",
       "name": "WadzPay Token",
       "symbol": "WTK",


### PR DESCRIPTION
[0x8A3cc832Bb6B255622E92dc9d4611F2A94d200DA](https://explorer.xinfin.network/address/xdc8A3cc832Bb6B255622E92dc9d4611F2A94d200DA#transactions) is another WXDC token which is used by globiance DEX. [Hummingbot](https://hummingbot.org/) use symbol to stand for token, it can not handle different tokens with same symbol. So I request add 0x8A3cc832Bb6B255622E92dc9d4611F2A94d200DA to xdc token list with new symbol WXDC2.